### PR TITLE
New features: custom end sound, start/end commands, progress bar color

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ const init = () => {
 
   const pomodoroType = APP.getPomodoroType(program);
 
-  pomodoro.setConfig(pomodoroType, program.timer, program.playSound);
+  pomodoro.setConfig(pomodoroType, program.timer);
 
   var bar = new progress(':timerFrom [:bar] :timerTo'[program.progressColor], {
     complete: '=',

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ program
   .option('-p, --play-sound <filepath>', 'Play a sound file when the timer expires')
   .option('--start-command <filepath>', 'Execute a shell command ansynchronously at the start of the timer. WARNING: The command is passed directly to a shell with the same user permissions this program runs under -- use with caution!')
   .option('--end-command <filepath>', 'Execute a shell command ansynchronously at the end of the timer. WARNING: The command is passed directly to a shell with the same user permissions this program runs under -- use with caution!')
+  .option('-c, --progress-color <color>', 'Color of the progress bar, as a valid colors.js text color', 'red')
   .option('-a, --add-task <task>', 'Add a new task', 'task')
   .parse(process.argv);
 
@@ -53,7 +54,7 @@ const init = () => {
 
   pomodoro.setConfig(pomodoroType, program.timer, program.playSound);
 
-  var bar = new progress(':timerFrom [:bar] :timerTo'.red, {
+  var bar = new progress(':timerFrom [:bar] :timerTo'[program.progressColor], {
     complete: '=',
     incomplete: ' ',
     width: 50,

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const progress = require('progress');
 const colors = require('colors');
 const program = require('commander');
 const pomodoro = require('./models/pomodoro');
+var player = require('play-sound')();
 
 const APP = {
   getPomodoroType: ({ shortbreak, longbreak, timer }) => {
@@ -35,13 +36,14 @@ program
   .option('-s, --shortbreak', 'Add short break timer')
   .option('-l, --longbreak', 'Add long break timer')
   .option('-t, --timer <time>', 'Add specific time in minutes', parseInt)
+  .option('-p, --play-sound <filepath>', 'Play a sound file when the timer expires')
   .option('-a, --add-task <task>', 'Add a new task', 'task')
   .parse(process.argv);
 
 const init = () => {
   const pomodoroType = APP.getPomodoroType(program);
 
-  pomodoro.setConfig(pomodoroType, program.timer);
+  pomodoro.setConfig(pomodoroType, program.timer, program.playSound);
 
   var bar = new progress(':timerFrom [:bar] :timerTo'.red, {
     complete: '=',
@@ -72,10 +74,17 @@ const notify = () => {
     title: 'Pomodoro Cli',
     message: pomodoro.getMessage(),
     icon: path.join(__dirname, 'images/pomodoro.png'),
-    sound: 'true',
+    sound: pomodoro.playSound ? 'false' : 'true',
   });
-
+  if (pomodoro.playSound) {
+    player.play(pomodoro.playSound, function(err) {
+      if (err) {
+        throw err;
+      }
+    });
+  }
   process.exit(0);
+
 };
 
 init();

--- a/index.js
+++ b/index.js
@@ -82,10 +82,10 @@ const notify = () => {
     title: 'Pomodoro Cli',
     message: pomodoro.getMessage(),
     icon: path.join(__dirname, 'images/pomodoro.png'),
-    sound: pomodoro.playSound ? 'false' : 'true',
+    sound: program.playSound ? 'false' : 'true',
   });
-  if (pomodoro.playSound) {
-    player.play(pomodoro.playSound, function(err) {
+  if (program.playSound) {
+    player.play(program.playSound, function(err) {
       if (err) {
         throw err;
       }

--- a/models/pomodoro.js
+++ b/models/pomodoro.js
@@ -11,7 +11,7 @@ var Pomodoro = function() {
   this.message = '';
 }
 
-Pomodoro.prototype.setConfig = function (type, timer) {
+Pomodoro.prototype.setConfig = function (type, timer, playSound) {
   const pomodoroConfig = {
     shortbreak : { time: 5, message: 'Let\'s get back to work!' },
     longbreak : { time: 10, message: 'Let\'s get back to work! What you\'ve been doing?' },
@@ -24,6 +24,7 @@ Pomodoro.prototype.setConfig = function (type, timer) {
   this.type = type;
   this.message = config.message;
   this.setTimer(config.time, 'minutes');
+  this.playSound = playSound;
 }
 
 Pomodoro.prototype.setTimer = (time, duration) => {

--- a/models/pomodoro.js
+++ b/models/pomodoro.js
@@ -11,7 +11,7 @@ var Pomodoro = function() {
   this.message = '';
 }
 
-Pomodoro.prototype.setConfig = function (type, timer, playSound) {
+Pomodoro.prototype.setConfig = function (type, timer) {
   const pomodoroConfig = {
     shortbreak : { time: 5, message: 'Let\'s get back to work!' },
     longbreak : { time: 10, message: 'Let\'s get back to work! What you\'ve been doing?' },
@@ -24,7 +24,6 @@ Pomodoro.prototype.setConfig = function (type, timer, playSound) {
   this.type = type;
   this.message = config.message;
   this.setTimer(config.time, 'minutes');
-  this.playSound = playSound;
 }
 
 Pomodoro.prototype.setTimer = (time, duration) => {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "commander": "^2.9.0",
     "moment": "^2.12.0",
     "node-notifier": "^4.5.0",
+    "play-sound": "^1.1.3",
     "progress": "^1.1.8"
   },
   "bin": {


### PR DESCRIPTION
I've extended this app with some features I'm finding useful, so I thought I'd submit them in a PR for your consideration. From the CLI help: 
```
  -p, --play-sound <filepath>   Play a sound file when the timer expires
  --start-command <filepath>    Execute a shell command ansynchronously at the start of the timer. WARNING: The command is passed directly to a shell with the same user permissions this program runs under -- use with caution!
  --end-command <filepath>      Execute a shell command ansynchronously at the end of the timer. WARNING: The command is passed directly to a shell with the same user permissions this program runs under -- use with caution!
  -c, --progress-color <color>  Color of the progress bar, as a valid colors.js text color (default: "red")
```

 * ```--play-sound``` is useful to customize the sounds played for different timers, and especially useful on systems that aren't supported natively by node-notifier
 * ```--start-command``` and ```--end-command``` are handy for automating any tasks at the beginning/end of a Pomodoro, such as logging start/end timestamps to a tracking file. I personally use it with a script I wrote that plays a sound every X seconds, kind of a mindfulness thing: https://gist.github.com/thehunmonkgroup/f7eb52913c4049d5e35007def3bfe026
 * ```--progress-bar``` is pretty obvious...the red isn't my favorite, and colors.js provides others, so this just exposes those options.