### PR TITLE
use width of current terminal window

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ const init = () => {
   var bar = new progress(':timerFrom [:bar] :timerTo'[program.progressColor], {
     complete: '=',
     incomplete: ' ',
-    width: 50,
+    width: process.stdout.columns,
     total: pomodoro.totalSeconds(),
     timerTo: pomodoro.getTime('timerTo'),
     timerFrom: pomodoro.getTime('timerFrom'),


### PR DESCRIPTION
Node provides a handy process.stdout.columns property to get the
width of the current terminal -- this seems a more sensible than
a hardcoded value.