### PR TITLE
add --player-binary arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Simple timer for [pomodoro technique]
     -l, --longbreak        Add long break timer
     -t, --timer <time>     Add specific time in minutes
     -a, --add-task <task>  Add a new task
- 		-p, --play-sound <filepath>   Play a sound file when the timer expires
-  	--start-command <filepath>    Execute a shell command ansynchronously at the start of the timer. WARNING: The command is passed directly to a shell with the same user permissions this program runs under -- use with caution!
-  	--end-command <filepath>      Execute a shell command ansynchronously at the end of the timer. WARNING: The command is passed directly to a shell with the same user permissions this program runs under -- use with caution!
-  	-c, --progress-color <color>  Color of the progress bar, as a valid colors.js text color (default: "red")
+ 	  -p, --play-sound <filepath>   Play a sound file when the timer expires
+    --player-binary <name>        System binary to use for playing sounds, default auto selects
+   	--start-command <filepath>    Execute a shell command ansynchronously at the start of the timer. WARNING: The command is passed directly to a shell with the same user permissions this program runs under -- use with caution!
+    --end-command <filepath>      Execute a shell command ansynchronously at the end of the timer. WARNING: The command is passed directly to a shell with the same user permissions this program runs under -- use with caution!
+    -c, --progress-color <color>  Color of the progress bar, as a valid colors.js text color (default: "red")
 ```

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ const progress = require('progress');
 const colors = require('colors');
 const program = require('commander');
 const pomodoro = require('./models/pomodoro');
-const player = require('play-sound')();
 const { spawn } = require('child_process');
 
 const APP = {
@@ -38,11 +37,18 @@ program
   .option('-l, --longbreak', 'Add long break timer')
   .option('-t, --timer <time>', 'Add specific time in minutes', parseInt)
   .option('-p, --play-sound <filepath>', 'Play a sound file when the timer expires')
+  .option('--player-binary <name>', 'System binary to use for playing sounds, default auto selects')
   .option('--start-command <filepath>', 'Execute a shell command ansynchronously at the start of the timer. WARNING: The command is passed directly to a shell with the same user permissions this program runs under -- use with caution!')
   .option('--end-command <filepath>', 'Execute a shell command ansynchronously at the end of the timer. WARNING: The command is passed directly to a shell with the same user permissions this program runs under -- use with caution!')
   .option('-c, --progress-color <color>', 'Color of the progress bar, as a valid colors.js text color', 'red')
   .option('-a, --add-task <task>', 'Add a new task', 'task')
   .parse(process.argv);
+
+const playerArgs = {};
+if (program.playerBinary) {
+  playerArgs.player = program.playerBinary;
+}
+const player = require('play-sound')(playerArgs);
 
 const init = () => {
 


### PR DESCRIPTION
The play-sound module auto selects the system binary to use when playing
files, and in some cases the selected binary may not work correctly.

The --player-binary argument can be used to specify which system binary
the play-sound module will use when playing files.